### PR TITLE
Replace All-Hands-AI references with OpenHands

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -62,10 +62,10 @@ jobs:
           context: .
           file: dockerfiles/${{ matrix.key }}.Dockerfile
           load: true
-          tags: ghcr.io/all-hands-ai/python-nodejs:${{ matrix.key }}
+          tags: ghcr.io/openhands/python-nodejs:${{ matrix.key }}
       - name: Run smoke tests
         run: |
-          docker run --rm ghcr.io/all-hands-ai/python-nodejs:${{ matrix.key }} sh -c "node --version && npm --version && yarn --version && python --version && pip --version && pipenv --version && poetry --version && uv --version"
+          docker run --rm ghcr.io/openhands/python-nodejs:${{ matrix.key }} sh -c "node --version && npm --version && yarn --version && python --version && pip --version && pipenv --version && poetry --version && uv --version"
       - name: Push image
         uses: docker/build-push-action@263435318d21b8e681c14492fe198d362a7d2c83 # v6
         with:
@@ -73,7 +73,7 @@ jobs:
           file: dockerfiles/${{ matrix.key }}.Dockerfile
           platforms: ${{ join(matrix.platforms) }}
           push: true
-          tags: ghcr.io/all-hands-ai/python-nodejs:${{ matrix.key }}
+          tags: ghcr.io/openhands/python-nodejs:${{ matrix.key }}
 
   release:
     name: Update versions.json and README.md

--- a/README.md
+++ b/README.md
@@ -116,17 +116,17 @@ Versions are kept up to date using official sources. For Python we scrape the _S
 
 ```bash
 # Pull from Docker Hub
-docker pull all-hands-ai/python-nodejs:latest
+docker pull openhands/python-nodejs:latest
 # Build from GitHub
-docker build -t all-hands-ai/python-nodejs github.com/All-Hands-AI/docker-python-nodejs
+docker build -t openhands/python-nodejs github.com/OpenHands/docker-python-nodejs
 # Run image
-docker run -it all-hands-ai/python-nodejs bash
+docker run -it openhands/python-nodejs bash
 ```
 
 ### Use as base image
 
 ```Dockerfile
-FROM all-hands-ai/python-nodejs:latest
+FROM openhands/python-nodejs:latest
 
 USER pn
 WORKDIR /home/pn/app


### PR DESCRIPTION
This PR replaces all occurrences of 'All-Hands-AI' with 'OpenHands' or 'openhands' while preserving case patterns.

## Changes made:
- `All-Hands-AI` → `OpenHands`
- `all-hands-ai` → `openhands`
- `ALL-HANDS-AI` → `OPENHANDS`
- Other case variations handled appropriately

This is part of the organization rebranding effort.

## Files changed:
- 2 files were modified

## Review notes:
- All changes are simple string replacements
- Case patterns are preserved
- No functional changes to code logic